### PR TITLE
Add WINDOW_SIZE option for faster transfers

### DIFF
--- a/extension/usbnetlite/bin/usbnetwork
+++ b/extension/usbnetlite/bin/usbnetwork
@@ -108,6 +108,10 @@ elif [ "${PASSWORD_OVERRIDE_ENABLED}" == "true" ] ; then
     SSH_DAEMON_OPTS="${SSH_DAEMON_OPTS} -Y ${PASSWORD}"
 fi
 
+if [ -n "${WINDOW_SIZE}" ] ; then
+    SSH_DAEMON_OPTS="${SSH_DAEMON_OPTS} -W ${WINDOW_SIZE}"
+fi
+
 # USB NET => USB MS
 usbnet_to_usbms() {
     kh_msg "switching from usbnet to usbms" I

--- a/extension/usbnetlite/etc/config
+++ b/extension/usbnetlite/etc/config
@@ -17,3 +17,6 @@ PORT="22"
 USE_WIFI="true"
 
 TWEAK_MAC_ADDRESS="false"
+
+# Uncomment to enable faster transfers but higher memory usage
+# WINDOW_SIZE="6291456"


### PR DESCRIPTION
The default used value is 24576 (24KiB) which makes for reeeeeally slow transfers. Adding a bigger value, like 6291456 (6MiB) makes transfers much faster, with the downside that it uses more memory, so I'm not setting this by default since Kindles and especially older models don't have much RAM.